### PR TITLE
Fix: Update oktaDiscoveryUrl in auth_okta_service.dart

### DIFF
--- a/example/lib/services/auth_okta_service.dart
+++ b/example/lib/services/auth_okta_service.dart
@@ -12,7 +12,7 @@ class AuthOktaService {
   static const String oktaIssuerUrl =
       'https://$oktaDomain/oauth2/$oktaAuthorizer';
   static const String oktaDiscoveryUrl =
-      'https://$oktaDomain/.well-known/openid-configuration';
+      '$oktaIssuerUrl/.well-known/openid-configuration';
 
   static const String oktaRedirectUrl =
       'com.bluestork.flutteroktaauth:/callback';


### PR DESCRIPTION
Fix: Android is not using the correct issuer URL. OKTA returning the Token but server is not able to validate it due to the issuer URL configuration issue.